### PR TITLE
chore: switch to integration-test-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "apidoc": "apidoc -o apidoc-out -i src/controllers/",
     "test": "istanbul test -- _mocha",
     "bump": "version-bump",
-    "integration": "integration all",
+    "integration": "integration-loader && integration all",
     "report-coverage": "codecov",
     "ci-npm-publish": "ci-publish"
   },
@@ -70,7 +70,7 @@
     "eslint-config-standard": "^6.2.0",
     "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-standard": "^2.0.1",
-    "five-bells-integration-test": "^4.1.0",
+    "five-bells-integration-test-loader": "^1.0.0",
     "istanbul": "^0.4.0",
     "methods": "^1.1.1",
     "mocha": "^3.1.2",
@@ -78,5 +78,11 @@
     "sinon": "^1.17.2",
     "spec-xunit-file": "0.0.1-3",
     "supertest": "^2.0.1"
+  },
+  "config": {
+    "five-bells-integration-test-loader": {
+      "module": "five-bells-integration-test",
+      "repo": "interledgerjs/five-bells-integration-test"
+    }
   }
 }


### PR DESCRIPTION
Currently, we have to bump the version of integration tests on every module, every time we change them. We also often get into deadlocks we have to resolve by skipping tests.

This is part of a series of pull requests to switch to five-bells-integration-test-loader, which will solve both problems by loading the integration tests according to the same rules as other modules: Use latest master, unless there is a branch of the same name, then use that branch.

It's probably easiest to understand by looking at the following two links:
* interledgerjs/five-bells-ledger@b241d14768b02a42a34dc42e91d5101db7de0525
* https://github.com/interledgerjs/five-bells-integration-test-loader